### PR TITLE
Solved issue #2: Undefined reference to variable when building with G…

### DIFF
--- a/modules/simulator/IntelSimulator.cpp
+++ b/modules/simulator/IntelSimulator.cpp
@@ -165,7 +165,7 @@ class IntelSimulator : public SimulatorGeneral<IntelSimulator> {
         gate_count_1qubit++;
 
         #ifdef GATE_LOGGING
-        writer.oneQubitGateCall("PShift(theta=" + std::to_string(angle) + ")", U.tostr(), qubitIndex);
+        writer.oneQubitGateCall("PShift(theta=" + std::to_string(angle) + ")", U.tostr(), qubit_idx);
         #endif
 
     }


### PR DESCRIPTION
Solved issue #2: Undefined reference to variable when building with Gate Logging enabled.

Replaced qubit_index with qubit_idx.