### PR TITLE
Use iqusoft intel-qs version

### DIFF
--- a/demos/encoding/CMakeLists.txt
+++ b/demos/encoding/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(exe_demo_encoding demo_encoding.cpp)
-target_link_libraries(exe_demo_encoding qnlp_simulator intel_qs)
+target_link_libraries(exe_demo_encoding qnlp_simulator iqs)

--- a/demos/hamming_RotY/CMakeLists.txt
+++ b/demos/hamming_RotY/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(exe_demo_hamming_RotY demo_hamming_RotY.cpp)
-target_link_libraries(exe_demo_hamming_RotY qnlp_simulator intel_qs)
+target_link_libraries(exe_demo_hamming_RotY qnlp_simulator iqs)

--- a/demos/hamming_similarity_example/CMakeLists.txt
+++ b/demos/hamming_similarity_example/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(hamming_similarity_example hamming_similarity_example.cpp)
-target_link_libraries(hamming_similarity_example qnlp_simulator intel_qs)
+target_link_libraries(hamming_similarity_example qnlp_simulator iqs)

--- a/demos/isc_2019/CMakeLists.txt
+++ b/demos/isc_2019/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(encode_corpus EncodeCorpus.cpp)
-target_link_libraries(encode_corpus qnlp_db intel_qs qnlp_simulator CLI11::CLI11 stdc++fs)
+target_link_libraries(encode_corpus qnlp_db iqs qnlp_simulator CLI11::CLI11 stdc++fs)
 
 add_executable(encode_corpus_mpi EncodeCorpus_MPI.cpp)
-target_link_libraries(encode_corpus_mpi qnlp_db intel_qs qnlp_simulator CLI11::CLI11 stdc++fs)
+target_link_libraries(encode_corpus_mpi qnlp_db iqs qnlp_simulator CLI11::CLI11 stdc++fs)

--- a/demos/nqubit_ControlledU/CMakeLists.txt
+++ b/demos/nqubit_ControlledU/CMakeLists.txt
@@ -6,4 +6,4 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_executable(exe_demo_nCU demo_nqubit_ControlledUnitary.cpp)
-target_link_libraries(exe_demo_nCU qnlp_simulator intel_qs)
+target_link_libraries(exe_demo_nCU qnlp_simulator iqs)

--- a/modules/gate_ops/diffusion/CMakeLists.txt
+++ b/modules/gate_ops/diffusion/CMakeLists.txt
@@ -10,6 +10,6 @@ target_include_directories(qnlp_diffusion INTERFACE $<BUILD_INTERFACE:${CMAKE_CU
 
 if(${CMAKE_TESTING_ENABLED})
     add_library(test_diffusion OBJECT test_diffusion.cpp)
-    target_link_libraries(test_diffusion Catch2::Catch2 qnlp_simulator intel_qs qnlp_diffusion)
+    target_link_libraries(test_diffusion Catch2::Catch2 qnlp_simulator iqs qnlp_diffusion)
     target_include_directories(test_diffusion PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${QHIPSTER_INC})
 endif()

--- a/modules/gate_ops/ncu/CMakeLists.txt
+++ b/modules/gate_ops/ncu/CMakeLists.txt
@@ -11,6 +11,6 @@ target_link_libraries(qnlp_ncu INTERFACE qnlp_utils)
 
 if(${CMAKE_TESTING_ENABLED})
     add_library(test_ncu OBJECT test_ncu.cpp)
-    target_link_libraries(test_ncu Catch2::Catch2 qnlp_simulator intel_qs)
+    target_link_libraries(test_ncu Catch2::Catch2 qnlp_simulator iqs)
     target_include_directories(test_ncu PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${QHIPSTER_INC})
 endif()

--- a/modules/gate_ops/oracle/CMakeLists.txt
+++ b/modules/gate_ops/oracle/CMakeLists.txt
@@ -10,6 +10,6 @@ target_include_directories(qnlp_oracle INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRE
 
 if(${CMAKE_TESTING_ENABLED})
     add_library(test_oracle OBJECT test_oracle.cpp)
-    target_link_libraries(test_oracle qnlp_oracle Catch2::Catch2 qnlp_simulator intel_qs)
+    target_link_libraries(test_oracle qnlp_oracle Catch2::Catch2 qnlp_simulator iqs )
     target_include_directories(test_oracle PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${QHIPSTER_INC})
 endif()

--- a/modules/simulator/CMakeLists.txt
+++ b/modules/simulator/CMakeLists.txt
@@ -10,10 +10,10 @@ set(QNLP_SIMULATOR_FILES IntelSimulator.cpp Simulator.hpp CACHE INTERNAL "" FORC
 
 add_library(qnlp_simulator STATIC ${QNLP_SIMULATOR_FILES})
 
-target_include_directories(qnlp_simulator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${QHIPSTER_INC})
-target_link_libraries(qnlp_simulator intel_qs qnlp_bitgroup qnlp_ncu qnlp_oracle qnlp_diffusion qnlp_qft qnlp_arithmetic qnlp_gatewriter qnlp_qft qnlp_binencode qnlp_hamming qnlp_utils)
+target_include_directories(qnlp_simulator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} iqs )
+target_link_libraries(qnlp_simulator iqs qnlp_bitgroup qnlp_ncu qnlp_oracle qnlp_diffusion qnlp_qft qnlp_arithmetic qnlp_gatewriter qnlp_qft qnlp_binencode qnlp_hamming qnlp_utils)
 
 if(${CMAKE_TESTING_ENABLED})
     add_library(test_simulator OBJECT test_simulator.cpp ${QNLP_SIMULATOR_FILES})
-    target_link_libraries(test_simulator Catch2::Catch2 qnlp_simulator intel_qs qnlp_ncu qnlp_diffusion qnlp_oracle qnlp_qft qnlp_binencode qnlp_hamming qnlp_utils)
+    target_link_libraries(test_simulator Catch2::Catch2 qnlp_simulator iqs qnlp_ncu qnlp_diffusion qnlp_oracle qnlp_qft qnlp_binencode qnlp_hamming qnlp_utils)
 endif()

--- a/modules/simulator/IntelSimulator.cpp
+++ b/modules/simulator/IntelSimulator.cpp
@@ -16,8 +16,8 @@
 
 #include "Simulator.hpp"
 #include "GateWriter.hpp"
-#include "qureg/qureg.hpp"
-#include "util/tinymatrix.hpp"
+#include "include/qureg.hpp"
+#include "include/tinymatrix.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <limits>

--- a/modules/test/CMakeLists.txt
+++ b/modules/test/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(${CMAKE_TESTING_ENABLED})
     add_executable(tests test_main.cpp)
 
-    target_link_libraries(tests Catch2::Catch2 test_bitgroup test_db test_simulator test_ncu test_qft test_arithmetic test_oracle test_diffusion test_binencode test_hamming intel_qs)
+    target_link_libraries(tests Catch2::Catch2 test_bitgroup test_db test_simulator test_ncu test_qft test_arithmetic test_oracle test_diffusion test_binencode test_hamming iqs)
     target_include_directories(tests PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${QHIPSTER_INC})
 
     include(CTest)

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -18,7 +18,7 @@ declare -a PIP_PACKAGES
 declare -a CONDA_PACKAGES
 declare -a PYTHON_CMDS
 
-GITHUB_REPOS=(  "intel/intel-qs"
+GITHUB_REPOS=(  "iqusoft/intel-qs"
                 "catchorg/Catch2::v2.7.0"
                 "CLIUtils/CLI11"
                 "pybind/pybind11"
@@ -30,18 +30,18 @@ PIP_PACKAGES=(  "multimethod" #used for multiple dispatch of certain function
                 "cython" # used during Python module setup (mpi4py)
                 "spacy" # additional NLP lib for tagging
 )
-CONDA_PACKAGES=("nltk::intel"
-                "jupyter::intel"
-                "numpy::intel"
-                "scipy::intel"
-                "tabulate::intel"
-                "mkl-include::intel"
-                "mkl-devel::intel"
-                "mkl-static::intel"
-                "networkx::intel"
-                "matplotlib::intel"
+CONDA_PACKAGES=("nltk"
+                "jupyter"
+                "numpy"
+                "scipy"
+                "tabulate"
+                "mkl-include"
+                "mkl-devel"
+                "mkl-static"
+                "networkx"
+                "matplotlib"
                 "tqdm::conda-forge"
-                "pandas::intel"
+                "pandas"
 )
 CMDS=(          "python -m nltk.downloader -d ${NLTK_DATA} all" #Download additional NLTK models
                 "python -m spacy download en_core_web_sm" #Download additional spacy models
@@ -139,7 +139,7 @@ function condaEnvSetup(){
     ${QNLP_ROOT}/third_party/downloads/${CONDA} -b -p ${QNLP_ROOT}/third_party/install/intel-qnlp_conda;
     source ${QNLP_ROOT}/third_party/install/intel-qnlp_conda/bin/activate ;
     conda update -n base conda -y;
-    conda create -n intel-qnlp -c intel -y python=3.7;
+    conda create -n intel-qnlp -y python=3.7;
     conda activate intel-qnlp #Activate said environment
 }
 


### PR DESCRIPTION
Closes #9 

Changes:
- Updates the intel-qs version to use https://github.com/iqusoft instead of https://github.com/intel
- Removes explicit intel-python dependency as can cause library issues on Mac OS 10.15. User can specify the intel channel themselves by overriding conda channel preferences in `~/.condarc`.